### PR TITLE
Should the rdfs:domain of gs1de:regulationTypeCode be gs1de:RegulatoryInformation?

### DIFF
--- a/currentVersion/gs1DEWebVoc.jsonld
+++ b/currentVersion/gs1DEWebVoc.jsonld
@@ -571,7 +571,7 @@
             "@value": "A code that indicates that a subject is in compliance with specific applicable government regulations."
         },
         "rdfs:domain": {
-            "@id": "owl:Thing"
+            "@id": "gs1de:RegulatoryInformation"
         },
         "rdfs:isDefinedBy": {
             "@id": "gs1de:"


### PR DESCRIPTION
I think the rdfs:domain for the property gs1de:regulationTypeCode should be gs1de:RegulatoryInformation rather than owl:Thing.

This would also align much better with the data modelling approach for the corresponding property/attribute in the GDSN data model - see https://navigator.gs1.org/gdsn/attribute-details?parent=RegulatoryInformation&name=regulationTypeCode&version=13